### PR TITLE
Drop Node.js 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
   - "8"
+
+os:
+  - linux
+  - osx
 
 git:
   depth: 300

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: "6"
     - nodejs_version: "8"
 
 install:

--- a/index.js
+++ b/index.js
@@ -3,6 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-const nodeMajorVersion = +process.versions.node.split('.')[0];
-const dist = nodeMajorVersion >= 7 ? './dist' : './dist6';
-module.exports = require(dist);
+module.exports = require('./dist');

--- a/package.json
+++ b/package.json
@@ -7,15 +7,12 @@
     "node": ">=8"
   },
   "scripts": {
-    "build": "npm run build:dist && npm run build:dist6",
-    "build:current": "lb-tsc",
-    "build:dist": "lb-tsc es2017",
-    "build:dist6": "lb-tsc es2015",
+    "build": "lb-tsc es2017",
     "build:apidocs": "lb-apidocs",
-    "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean loopback-grpc*.tgz dist dist6 package api-docs",
+    "build:watch": "lb-tsc es2017 --watch",
+    "clean": "lb-clean loopback-grpc*.tgz dist package api-docs",
     "prepublishOnly": "npm run build && npm run build:apidocs",
-    "pretest": "npm run lint:fix && npm run clean && npm run build:current",
+    "pretest": "npm run lint:fix && npm run clean && npm run build",
     "test": "lb-mocha \"DIST/test/unit/**/*.js\" \"DIST/test/acceptance/**/*.js\"",
     "lint": "npm run prettier:check && npm run tslint",
     "lint:fix": "npm run prettier:fix && npm run tslint:fix",
@@ -46,8 +43,7 @@
     "README.md",
     "index.js",
     "index.d.ts",
-    "dist",
-    "dist6"
+    "dist"
   ],
   "dependencies": {
     "@loopback/context": "^4.0.0-alpha.30",


### PR DESCRIPTION
### Description
LoopBack4 is dropping support for Node 6 because it is no longer LTS and doesn't support newer features. It's best for extensions to align with it.

BREAKING CHANGE: Support for Node.js version lower than 8.0 has been dropped. Please upgrade to Node 8 or higher.

#### Related issues

- follow up to https://github.com/strongloop/loopback4-extension-grpc/commit/65414e1dc9e55dbdcee309e7f1ece7f9fde65792
- related to https://github.com/strongloop/loopback-next/issues/611

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)