### PR TITLE
Upgrade to loopback-next 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xanthous/loopback4-extension-grpc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A gRPC extencion for LoopBack Next",
   "main": "index.js",
   "engines": {
@@ -52,7 +52,7 @@
     "@loopback/metadata": "^1.0.0",
     "@loopback/repository": "^1.0.0",
     "@loopback/rest": "^1.0.0",
-    "@mean-expert/protoc-ts": "0.0.2",
+    "@xanthous/protoc-ts": "^0.0.4",
     "glob": "^7.1.2",
     "grpc": "^1.6.6",
     "protobufjs": "^6.8.0"

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "@loopback/grpc",
-  "version": "1.0.0-alpha.2",
+  "name": "@xanthous/loopback4-extension-grpc",
+  "version": "1.0.0",
   "description": "A gRPC extencion for LoopBack Next",
   "main": "index.js",
   "engines": {
     "node": ">=8"
   },
   "scripts": {
-    "build": "lb-tsc es2017",
+    "build": "lb-tsc es2017 --outDir dist",
     "build:apidocs": "lb-apidocs",
-    "build:watch": "lb-tsc es2017 --watch",
+    "build:watch": "lb-tsc es2017 --outDir dist --watch",
     "clean": "lb-clean loopback-grpc*.tgz dist package api-docs",
     "prepublishOnly": "npm run build && npm run build:apidocs",
     "pretest": "npm run lint:fix && npm run clean && npm run build",
@@ -47,19 +47,19 @@
     "compilers"
   ],
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.30",
-    "@loopback/core": "^4.0.0-alpha.32",
-    "@loopback/metadata": "^4.0.0-alpha.9",
-    "@loopback/repository": "^4.0.0-alpha.28",
-    "@loopback/rest": "^4.0.0-alpha.24",
+    "@loopback/context": "^1.0.0",
+    "@loopback/core": "^1.0.0",
+    "@loopback/metadata": "^1.0.0",
+    "@loopback/repository": "^1.0.0",
+    "@loopback/rest": "^1.0.0",
     "@mean-expert/protoc-ts": "0.0.2",
     "glob": "^7.1.2",
     "grpc": "^1.6.6",
     "protobufjs": "^6.8.0"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
-    "@loopback/testlab": "^4.0.0-alpha.23",
+    "@loopback/build": "^1.0.0",
+    "@loopback/testlab": "^1.0.0",
     "@types/glob": "^5.0.35"
   }
 }

--- a/src/grpc.server.ts
+++ b/src/grpc.server.ts
@@ -1,6 +1,7 @@
 import {
   Application,
   CoreBindings,
+  BindingKey,
   Server,
   ControllerClass,
 } from '@loopback/core';
@@ -35,6 +36,9 @@ export class GrpcServer extends Context implements Server {
    * GRPCBindings.CONFIG).
    *
    */
+
+  listening: boolean = true;
+
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE) protected app: Application,
     @inject(GrpcBindings.GRPC_SERVER) protected server: grpc.Server,
@@ -126,7 +130,6 @@ export class GrpcServer extends Context implements Server {
       handleUnary().then(
         result => callback(null, result),
         error => {
-          debugger;
           callback(error);
         },
       );
@@ -137,9 +140,8 @@ export class GrpcServer extends Context implements Server {
           .toClass(ctor)
           .inScope(BindingScope.CONTEXT);
         context.bind(GrpcBindings.GRPC_METHOD_NAME).to(methodName);
-        const sequence: GrpcSequence = await context.get(
-          GrpcBindings.GRPC_SEQUENCE,
-        );
+        const key: BindingKey<GrpcSequence> = BindingKey.create<GrpcSequence>(GrpcBindings.GRPC_SEQUENCE);
+        const sequence: GrpcSequence = await context.get(key);
         return sequence.unaryCall(call);
       }
     };


### PR DESCRIPTION
### Description

We would like to use the package to create gRPC endpoints, but we found a few issues, mostly due to dependency not being up-to-date.

#### Related issues

TODO: We also made an update to `@mean-expert/protoc-ts` to have the `rpc` service return Promises. We will slowly clean this up.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)